### PR TITLE
chore: add flags for base, gnosis, polygonzkevm

### DIFF
--- a/crytic_compile/cryticparser/cryticparser.py
+++ b/crytic_compile/cryticparser/cryticparser.py
@@ -386,6 +386,30 @@ def _init_etherscan(parser: ArgumentParser) -> None:
     )
 
     group_etherscan.add_argument(
+        "--base-apikey",
+        help="Basescan API key.",
+        action="store",
+        dest="base_api_key",
+        default=DEFAULTS_FLAG_IN_CONFIG["etherscan_api_key"],
+    )
+
+    group_etherscan.add_argument(
+        "--gno-apikey",
+        help="Gnosisscan API key.",
+        action="store",
+        dest="gno_api_key",
+        default=DEFAULTS_FLAG_IN_CONFIG["etherscan_api_key"],
+    )
+
+    group_etherscan.add_argument(
+        "--polyzk-apikey",
+        help="zkEVM Polygonscan API key.",
+        action="store",
+        dest="polyzk_api_key",
+        default=DEFAULTS_FLAG_IN_CONFIG["etherscan_api_key"],
+    )
+
+    group_etherscan.add_argument(
         "--etherscan-export-directory",
         help="Directory in which to save the analyzed contracts.",
         action="store",


### PR DESCRIPTION
Add missing flags for new network options.

I double checked that the flag storage values match your changes for the new networks (`base_api_key`, `gno_api_key` and `polyzk_api_key`)